### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/skyfe79/AndroidChannel.svg?branch=master)](http://www.android-gems.com/lib/skyfe79/AndroidChannel)
+
 # AndroidChannel
 
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-AndroidChannel-green.svg?style=flat)](https://android-arsenal.com/details/1/2547)


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/skyfe79/AndroidChannel , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/skyfe79/AndroidChannel.svg?branch=master)](http://www.android-gems.com/lib/skyfe79/AndroidChannel)
